### PR TITLE
Meaningful errors when config options are missing

### DIFF
--- a/lib/s3_cors_fileupload/rails/config.rb
+++ b/lib/s3_cors_fileupload/rails/config.rb
@@ -2,6 +2,8 @@ require 'yaml'
 
 module S3CorsFileupload
   module Config
+    MissingOptionError = Class.new(RuntimeError)
+
     # this allows us to lazily instantiate the configuration by reading it in when it needs to be accessed
     class << self
       # if a method is called on the class, attempt to look it up in the config array
@@ -13,10 +15,14 @@ module S3CorsFileupload
         end
       end
 
+      def path
+        ::Rails.root.join('config', 'amazon_s3.yml')
+      end
+
       private
 
       def config
-        @config ||= YAML.load(ERB.new(File.read(File.join(::Rails.root, 'config', 'amazon_s3.yml'))).result)[::Rails.env]
+        @config ||= YAML.load(ERB.new(File.read(path)).result)[::Rails.env]
       rescue
         warn('WARNING: s3_cors_fileupload gem was unable to locate a configuration file in config/amazon_s3.yml and may not ' +
              'be able to function properly.  Please run `rails generate s3_cors_upload:install` before proceeding.')

--- a/lib/s3_cors_fileupload/rails/policy_helper.rb
+++ b/lib/s3_cors_fileupload/rails/policy_helper.rb
@@ -14,6 +14,9 @@ module S3CorsFileupload
         :max_file_size => Config.max_file_size || 524288000,
         :bucket => Config.bucket
       }.merge(_options).merge(:secret_access_key => Config.secret_access_key)
+
+      ensure_option_is_set :bucket
+      ensure_option_is_set :secret_access_key
     end
 
     # generate the policy document that amazon is expecting.
@@ -47,6 +50,14 @@ module S3CorsFileupload
             self.policy_document
           )
         ).gsub(/\n/, '')
+    end
+
+    private
+
+    def ensure_option_is_set(option)
+      if @options[option].blank?
+        raise S3CorsFileupload::Config::MissingOptionError, "#{option} is a required option in #{S3CorsFileupload::Config.path}"
+      end
     end
   end
 end

--- a/spec/lib/s3_cors_fileupload/rails/policy_helper_spec.rb
+++ b/spec/lib/s3_cors_fileupload/rails/policy_helper_spec.rb
@@ -41,6 +41,30 @@ describe S3CorsFileupload::PolicyHelper do
         it { policy_helper.options[:bucket].should == 'foobar' }
       end
     end
+
+    context "missing required configuration options" do
+      context "missing bucket" do
+        before { S3CorsFileupload::Config.stub(:bucket) { '' } }
+
+        it 'raises a meaningful error' do
+          expect {
+            policy_helper
+          }.to raise_error(S3CorsFileupload::Config::MissingOptionError,
+                           "bucket is a required option in #{S3CorsFileupload::Config.path}")
+        end
+      end
+
+      context "missing secret_access_key" do
+        before { S3CorsFileupload::Config.stub(:secret_access_key) { '' } }
+
+        it 'raises a meaningful error' do
+          expect {
+            policy_helper
+          }.to raise_error(S3CorsFileupload::Config::MissingOptionError,
+                           "secret_access_key is a required option in #{S3CorsFileupload::Config.path}")
+        end
+      end
+    end
   end
 
   describe "Instance Methods" do


### PR DESCRIPTION
I was receiving the following error when accessing /source_files and it took me a few minutes to realize I was missing some configuration options.

```
no implicit conversion of nil into String

s3_cors_fileupload (0.3.0) lib/s3_cors_fileupload/rails/policy_helper.rb:44:in `digest'
s3_cors_fileupload (0.3.0) lib/s3_cors_fileupload/rails/policy_helper.rb:44:in `upload_signature'
s3_cors_fileupload (0.3.0) lib/s3_cors_fileupload/rails/form_helper.rb:30:in `s3_cors_fileupload_form_tag'
app/views/s3_uploads/index.html.haml:5:in `_app_views_s__uploads_index_html_haml__634519600383552528_70251462003260'
```

This pull request does some assertions to ensure that the configuration options are set prior to calculating the upload signature. A better solution might validate this information when the yaml file is read, but it seems like that was a much larger change to put in place.
