### PR TITLE
Read config acl

### DIFF
--- a/lib/s3_cors_fileupload/rails/policy_helper.rb
+++ b/lib/s3_cors_fileupload/rails/policy_helper.rb
@@ -10,7 +10,7 @@ module S3CorsFileupload
     def initialize(_options = {})
       # default max_file_size to 500 MB if nothing is received
       @options = {
-        :acl => 'public-read',
+        :acl => Config.acl || 'public-read',
         :max_file_size => Config.max_file_size || 524288000,
         :bucket => Config.bucket
       }.merge(_options).merge(:secret_access_key => Config.secret_access_key)


### PR DESCRIPTION
the object acl is always "public-read" for files uploaded, it never use the value acl in the config "amazon_s3.yml"  
